### PR TITLE
Bumped django-markdown version and added ImportError handling

### DIFF
--- a/easy_cms/admin.py
+++ b/easy_cms/admin.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.db import models
 
 from hvad.admin import TranslatableAdmin, TranslatableStackedInline
-from django_markdown.widgets import MarkdownWidget
 
 from easy_cms.models import Placeholder, Content
 
@@ -25,9 +24,13 @@ class ContentAdmin(TranslatableAdmin):
     list_filter = ('site',)
     inlines = [ContentInline]
     if getattr(settings, 'CMS_MARKDOWN_ENABLED', False):
-        formfield_overrides = {
-            models.TextField: {'widget': MarkdownWidget},
-        }
+        try:
+            from django_markdown.widgets import MarkdownWidget
+            formfield_overrides = {
+                models.TextField: {'widget': MarkdownWidget},
+            }
+        except ImportError:
+            pass
 
 
 admin.site.register(Placeholder, PlaceholderAdmin)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'django>=1.5',
         'jsonfield==0.9.20',
         'django-hvad==0.4.1',
-        'django-markdown==0.6.1',
+        'django-markdown==0.7.0',
     ],
     dependency_links=[
         'https://github.com/KristianOellegaard/django-hvad.git#egg=django-hvad'


### PR DESCRIPTION
I've have fixed the problem in django-markdown and bumped the version to 0.7.0, no need to put django_markdown into INSTALLED_APPS now unless it is not enabled.
