### PR TITLE
django.utils.importlib is deprecated in django 1.9

### DIFF
--- a/easy_cms/admin.py
+++ b/easy_cms/admin.py
@@ -12,17 +12,9 @@ class PlaceholderAdmin(admin.ModelAdmin):
     list_filter = ('view_name', 'site')
 
 
-class ContentInline(TranslatableStackedInline):
-    model = Content
-    extra = 0
-    fields = ['name', 'description', 'url', 'image', 'title', 'tagline',
-              'content']
-
-
 class ContentAdmin(TranslatableAdmin):
     list_display = ('id', 'site', 'name', 'created_at')
     list_filter = ('site',)
-    inlines = [ContentInline]
     if getattr(settings, 'CMS_MARKDOWN_ENABLED', False):
         try:
             from django_markdown.widgets import MarkdownWidget

--- a/easy_cms/middleware.py
+++ b/easy_cms/middleware.py
@@ -1,7 +1,7 @@
 import json
 
 from django.conf import settings
-django.contrib.sites.shortcuts import get_current_site
+from django.contrib.sites.shortcuts import get_current_site
 from django.http import Http404, HttpResponse, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404
 from django.template import loader, RequestContext

--- a/easy_cms/middleware.py
+++ b/easy_cms/middleware.py
@@ -1,7 +1,7 @@
 import json
 
 from django.conf import settings
-from django.contrib.sites.models import get_current_site
+django.contrib.sites.shortcuts import get_current_site
 from django.http import Http404, HttpResponse, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404
 from django.template import loader, RequestContext

--- a/easy_cms/utils.py
+++ b/easy_cms/utils.py
@@ -6,7 +6,7 @@ def generic_autodiscover(module_name):
     Usage:
         generic_autodiscover('commands') <-- find all commands.py and load 'em
     """
-    from django.utils.importlib import import_module
+    from importlib import import_module
     from django.core.exceptions import ImproperlyConfigured
     import imp
     import sys

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         'django>=1.5',
         'jsonfield==0.9.20',
-        'django-hvad==0.4.1',
+        'django-hvad>=0.4.1',
         'django-markdown==0.7.0',
     ],
     dependency_links=[


### PR DESCRIPTION
using importlib from std lib.
